### PR TITLE
fix: update sidebar link for document template from /pages to /documents

### DIFF
--- a/app/components/dashboard/DashboardSidebar.vue
+++ b/app/components/dashboard/DashboardSidebar.vue
@@ -164,11 +164,11 @@
         </NuxtLink>
         
         <NuxtLink
-          to="/dashboard/document-templates"
+          to="/documents"
           class="group flex items-center px-2 py-2 text-sm font-medium rounded-md transition-colors"
-          :class="isActiveRoute('/dashboard/document-templates') ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'"
+          :class="isActiveRoute('/documents') ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'"
         >
-          <svg class="mr-3 h-5 w-5" :class="isActiveRoute('/dashboard/document-templates') ? 'text-blue-500' : 'text-gray-400 group-hover:text-gray-500'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="mr-3 h-5 w-5" :class="isActiveRoute('/documents') ? 'text-blue-500' : 'text-gray-400 group-hover:text-gray-500'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 2a1 1 0 000 2h6a1 1 0 100-2H9z"></path>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6z"></path>


### PR DESCRIPTION
- Fixed incorrect routing in DashboardSidebar.vue
- Changed Template Dokumen menu link from /pages to /documents
- Updated isActiveRoute condition to match /documents route
- Ensures proper navigation to documents management page